### PR TITLE
Remove unnecessary synthesis LLM call and fix double-scoring

### DIFF
--- a/src/graph_tot/dspy_modules.py
+++ b/src/graph_tot/dspy_modules.py
@@ -281,7 +281,7 @@ class GraphToTSolver(dspy.Module):
         Run ToT beam search and return the final answer.
 
         Returns a dspy.Prediction with fields:
-          answer      — final synthesised answer string
+          answer      — answer string from best branch
           best_trace  — reasoning trace from the best-scoring branch
           best_score  — float score of the best branch
           all_branches — list of branch dicts (for logging/inspection)


### PR DESCRIPTION
## Summary
- Removed `FinalAnswerSignature` and `self.synthesizer` — the best branch's answer is now returned directly, matching the paper's approach and avoiding prose distortion of terse entity-list answers
- Eliminated double-scoring on single-round runs (`max_rounds=1`) by reusing the loop's scored results instead of re-scoring after the loop, halving evaluator LLM calls

## Test plan
- [x] Run `uv run python main.py --demo --k 3 --b 1 --max-iters 12` and verify answer comes directly from best branch (no synthesis paraphrasing)
- [x] Compare LLM call count before/after — should see fewer evaluator calls with `max_rounds=1`
- [x] Run with `--max-rounds 2` to verify multi-round still works correctly

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)