### PR TITLE
Add pluggable graph interface and node-store abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,37 @@ load_compiled_solver(solver, "./compiled/solver.json")
 result = solver(question="What compounds treat diabetes mellitus?")
 ```
 
+
+### Bring your own graph backend
+
+`GraphToTSolver` only needs a graph object that exposes the four tool methods (`retrieve_node`, `node_feature`, `neighbour_check`, `node_degree`) plus `get_tools()`.
+
+This package now exposes:
+- `GraphToolInterface` — protocol describing that tool contract
+- `GraphNodeStore` — abstract loader for node data from any source
+- `JsonPickleGraphStore` — default implementation for current GRBench JSON/pickle files
+
+So you can integrate domain-specific backends such as Neo4j, RDF/OWL parsers, or custom services by implementing a `GraphNodeStore` (or directly implementing `GraphToolInterface`).
+
+```python
+from graph_tot import GraphEnvironment, GraphNodeStore
+
+class Neo4jStore(GraphNodeStore):
+    @property
+    def identity(self) -> str:
+        return "neo4j://my-db/v1"
+
+    def iter_nodes(self):
+        # yield (node_id, node_type, node_data={"features": ..., "neighbors": ...})
+        ...
+
+env = GraphEnvironment(
+    graph_path=None,
+    faiss_cache_dir="./data/cache",
+    node_store=Neo4jStore(),
+)
+```
+
 ---
 
 ## Project structure

--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ This package now exposes:
 - `GraphToolInterface` — protocol describing that tool contract
 - `GraphNodeStore` — abstract loader for node data from any source
 - `JsonPickleGraphStore` — default implementation for current GRBench JSON/pickle files
+- `RdfOwlXmlGraphStore` — built-in implementation for `.rdf` / `.owl` / RDF XML files
 
-So you can integrate domain-specific backends such as Neo4j, RDF/OWL parsers, or custom services by implementing a `GraphNodeStore` (or directly implementing `GraphToolInterface`).
+So you can integrate domain-specific backends such as Neo4j or custom services by implementing a `GraphNodeStore` (or directly implementing `GraphToolInterface`).
 
 ```python
 from graph_tot import GraphEnvironment, GraphNodeStore

--- a/src/graph_tot/__init__.py
+++ b/src/graph_tot/__init__.py
@@ -1,4 +1,11 @@
-from .graph_env import GraphEnvironment, ToolResult, ErrorCode
+from .graph_env import (
+    GraphEnvironment,
+    ToolResult,
+    ErrorCode,
+    GraphToolInterface,
+    GraphNodeStore,
+    JsonPickleGraphStore,
+)
 from .dspy_modules import GraphToTSolver, GraphToTAgent, TreeOfThoughtEvaluator, BranchDict
 from .data_loader import (
     load_grbench_qa, find_graph_file, check_graph_available,
@@ -17,6 +24,9 @@ __all__ = [
     "BranchDict",
     "ToolResult",
     "ErrorCode",
+    "GraphToolInterface",
+    "GraphNodeStore",
+    "JsonPickleGraphStore",
     # Data loading
     "load_grbench_qa",
     "find_graph_file",

--- a/src/graph_tot/__init__.py
+++ b/src/graph_tot/__init__.py
@@ -5,6 +5,7 @@ from .graph_env import (
     GraphToolInterface,
     GraphNodeStore,
     JsonPickleGraphStore,
+    RdfOwlXmlGraphStore,
 )
 from .dspy_modules import GraphToTSolver, GraphToTAgent, TreeOfThoughtEvaluator, BranchDict
 from .data_loader import (
@@ -27,6 +28,7 @@ __all__ = [
     "GraphToolInterface",
     "GraphNodeStore",
     "JsonPickleGraphStore",
+    "RdfOwlXmlGraphStore",
     # Data loading
     "load_grbench_qa",
     "find_graph_file",

--- a/src/graph_tot/graph_env.py
+++ b/src/graph_tot/graph_env.py
@@ -19,7 +19,8 @@ import os
 import pickle
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Optional, Protocol, runtime_checkable
 
 import numpy as np
 
@@ -69,6 +70,90 @@ class ErrorCode:
     INDEX_UNINITIALIZED = "INDEX_UNINITIALIZED"
 
 
+@runtime_checkable
+class GraphToolInterface(Protocol):
+    """Interface for graph backends consumable by GraphToTAgent.
+
+    Users can bring their own graph implementation (Neo4j, RDF/OWL, APIs, etc.)
+    by implementing this protocol and passing the instance to GraphToTSolver.
+    """
+
+    def retrieve_node(self, keyword: str) -> str:
+        ...
+
+    def node_feature(self, node_id: str, feature: str) -> str:
+        ...
+
+    def neighbour_check(self, node_id: str, neighbor_type: str) -> str:
+        ...
+
+    def node_degree(self, node_id: str, neighbor_type: str) -> str:
+        ...
+
+    def get_tools(self) -> list:
+        ...
+
+
+class GraphNodeStore(ABC):
+    """Abstract adapter for loading graph nodes from arbitrary sources.
+
+    Implementations can read from local files, databases, or remote services.
+    """
+
+    @property
+    @abstractmethod
+    def identity(self) -> str:
+        """Stable identity used for cache keying (path, URI, version, etc.)."""
+
+    @abstractmethod
+    def iter_nodes(self) -> Iterable[tuple[str, str, dict[str, Any]]]:
+        """Yield (node_id, node_type, node_data) tuples for all graph nodes."""
+
+
+class JsonPickleGraphStore(GraphNodeStore):
+    """GraphNodeStore implementation for the current GRBench JSON/pickle schema."""
+
+    def __init__(self, graph_path: str | Path) -> None:
+        self.graph_path = Path(graph_path)
+        self.graph: dict[str, Any] = {}
+        self._load()
+
+    @property
+    def identity(self) -> str:
+        return str(self.graph_path)
+
+    def _load(self) -> None:
+        if not self.graph_path.exists():
+            raise FileNotFoundError(
+                f"Graph file not found: {self.graph_path}\n"
+                "Download the healthcare graph from:\n"
+                "  https://drive.google.com/drive/folders/1DJIgRZ3G-TOf7h0-Xub5_sE4slBUEqy9\n"
+                f"Then place it at: {self.graph_path}"
+            )
+
+        suffix = self.graph_path.suffix.lower()
+        if suffix == ".json":
+            with open(self.graph_path, "r", encoding="utf-8") as f:
+                self.graph = json.load(f)
+        elif suffix in (".pkl", ".pickle"):
+            with open(self.graph_path, "rb") as f:
+                self.graph = pickle.load(f)
+        else:
+            try:
+                with open(self.graph_path, "r", encoding="utf-8") as f:
+                    self.graph = json.load(f)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                with open(self.graph_path, "rb") as f:
+                    self.graph = pickle.load(f)
+
+    def iter_nodes(self) -> Iterable[tuple[str, str, dict[str, Any]]]:
+        for node_type, nodes in self.graph.items():
+            if not isinstance(nodes, dict):
+                continue
+            for node_id, node_data in nodes.items():
+                yield node_id, node_type, node_data
+
+
 def _graph_fingerprint(graph_path: str) -> str:
     """Return a short fingerprint of a graph file for use in cache filenames.
 
@@ -88,26 +173,30 @@ def _graph_fingerprint(graph_path: str) -> str:
 
 class GraphEnvironment:
     """
-    Wraps a GRBench knowledge graph and exposes four ReAct-compatible tool methods.
+    Wraps a graph backend and exposes four ReAct-compatible tool methods.
 
-    The graph must be in one of these formats:
-      - JSON: nested dict  {node_type: {node_id: {features: {...}, neighbors: {...}}}}
-      - Pickle: same structure serialised with pickle
+    By default, it uses JsonPickleGraphStore for the GRBench JSON/pickle schema.
+    You can pass a custom GraphNodeStore to load nodes from other sources
+    (e.g., Neo4j, RDF/OWL parsers, or remote APIs).
 
     A FAISS index over node-name embeddings is built on first use and cached.
     """
 
     def __init__(
         self,
-        graph_path: str | Path,
+        graph_path: str | Path | None,
         faiss_cache_dir: str | Path,
         embedding_model: str = DEFAULT_EMBEDDING_MODEL,
         top_k: int = 1,
+        node_store: Optional[GraphNodeStore] = None,
     ) -> None:
-        self.graph_path = Path(graph_path)
+        if graph_path is None and node_store is None:
+            raise ValueError("graph_path is required when node_store is not provided")
+        self.graph_path = Path(graph_path) if graph_path is not None else Path(node_store.identity)
         self.faiss_cache_dir = Path(faiss_cache_dir)
         self.embedding_model_name = embedding_model
         self.top_k = top_k
+        self.node_store = node_store or JsonPickleGraphStore(self.graph_path)
 
         # Will be populated by _load_graph()
         self.graph: dict = {}
@@ -127,49 +216,23 @@ class GraphEnvironment:
     # ------------------------------------------------------------------
 
     def _load_graph(self) -> None:
-        """Load graph from JSON or pickle and build a flat node index."""
-        if not self.graph_path.exists():
-            raise FileNotFoundError(
-                f"Graph file not found: {self.graph_path}\n"
-                "Download the healthcare graph from:\n"
-                "  https://drive.google.com/drive/folders/1DJIgRZ3G-TOf7h0-Xub5_sE4slBUEqy9\n"
-                f"Then place it at: {self.graph_path}"
-            )
-
-        suffix = self.graph_path.suffix.lower()
-        if suffix == ".json":
-            with open(self.graph_path, "r", encoding="utf-8") as f:
-                self.graph = json.load(f)
-        elif suffix in (".pkl", ".pickle"):
-            with open(self.graph_path, "rb") as f:
-                self.graph = pickle.load(f)
-        else:
-            # Try JSON first, then pickle
-            try:
-                with open(self.graph_path, "r", encoding="utf-8") as f:
-                    self.graph = json.load(f)
-            except (UnicodeDecodeError, json.JSONDecodeError):
-                with open(self.graph_path, "rb") as f:
-                    self.graph = pickle.load(f)
-
+        """Load graph from the configured GraphNodeStore and build flat indexes."""
         seen: set[str] = set()
-        for node_type, nodes in self.graph.items():
-            if not isinstance(nodes, dict):
+        self.graph = getattr(self.node_store, "graph", {})
+        for nid, node_type, node_data in self.node_store.iter_nodes():
+            if nid in seen:
+                logger.warning("Duplicate node ID %s in type %s; skipping", nid, node_type)
                 continue
-            for nid, node_data in nodes.items():
-                if nid in seen:
-                    logger.warning("Duplicate node ID %s in type %s; skipping", nid, node_type)
-                    continue
-                seen.add(nid)
-                self.graph_index[nid] = node_data
-                self.doc_lookup.append(nid)
-                self.doc_type.append(node_type)
+            seen.add(nid)
+            self.graph_index[nid] = node_data
+            self.doc_lookup.append(nid)
+            self.doc_type.append(node_type)
 
         logger.info(
             "Graph loaded: %d nodes across %d types from %s",
             len(self.graph_index),
             len(self.graph),
-            self.graph_path,
+            self.node_store.identity,
         )
 
     # ------------------------------------------------------------------
@@ -196,7 +259,8 @@ class GraphEnvironment:
 
         self.faiss_cache_dir.mkdir(parents=True, exist_ok=True)
         safe_name = self.embedding_model_name.replace("/", "_")
-        fingerprint = _graph_fingerprint(str(self.graph_path))
+        fingerprint_source = getattr(getattr(self, "node_store", None), "identity", str(self.graph_path))
+        fingerprint = _graph_fingerprint(fingerprint_source)
         cache_file = self.faiss_cache_dir / f"faiss_{safe_name}_{fingerprint}.pkl"
         logger.info(
             "FAISS cache key: model=%s graph_fingerprint=%s path=%s",

--- a/tests/test_graph_interface.py
+++ b/tests/test_graph_interface.py
@@ -1,6 +1,12 @@
 """Tests for pluggable graph interfaces and stores."""
 
-from src.graph_tot.graph_env import GraphEnvironment, GraphNodeStore, GraphToolInterface
+from src.graph_tot.graph_env import (
+    GraphEnvironment,
+    GraphNodeStore,
+    GraphToolInterface,
+    RdfOwlXmlGraphStore,
+    _make_default_node_store,
+)
 
 
 class InMemoryStore(GraphNodeStore):
@@ -52,3 +58,43 @@ class TestCustomNodeStoreLoading:
         assert "Disease::D001" in env.graph_index
         assert env.doc_lookup == ["Disease::D001", "Compound::C001"]
         assert env.doc_type == ["Disease", "Compound"]
+
+
+class TestRdfOwlXmlGraphStore:
+    def test_parses_rdf_xml_nodes_features_and_edges(self, tmp_path):
+        rdf_xml = """<?xml version="1.0"?>
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:ex="http://example.org/"
+    xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Class rdf:about="http://example.org#Disease">
+    <rdfs:label>Disease</rdfs:label>
+    <ex:relatedTo rdf:resource="http://example.org#Symptom"/>
+  </owl:Class>
+  <rdf:Description rdf:about="http://example.org#Symptom">
+    <rdfs:label>Symptom</rdfs:label>
+    <ex:description>Clinical finding</ex:description>
+  </rdf:Description>
+</rdf:RDF>
+"""
+        path = tmp_path / "toy.owl"
+        path.write_text(rdf_xml, encoding="utf-8")
+
+        store = RdfOwlXmlGraphStore(path)
+        nodes = {(nid, ntype): data for nid, ntype, data in store.iter_nodes()}
+
+        assert ("Disease", "Class") in nodes
+        assert nodes[("Disease", "Class")]["features"]["name"] == "Disease"
+        assert nodes[("Disease", "Class")]["neighbors"]["relatedTo"] == ["Symptom"]
+
+        assert ("Symptom", "Resource") in nodes
+        assert nodes[("Symptom", "Resource")]["features"]["description"] == "Clinical finding"
+
+
+class TestDefaultStoreSelection:
+    def test_selects_rdf_store_for_owl_extension(self, tmp_path):
+        path = tmp_path / "toy.owl"
+        path.write_text("<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/>", encoding="utf-8")
+        store = _make_default_node_store(path)
+        assert isinstance(store, RdfOwlXmlGraphStore)

--- a/tests/test_graph_interface.py
+++ b/tests/test_graph_interface.py
@@ -1,0 +1,54 @@
+"""Tests for pluggable graph interfaces and stores."""
+
+from src.graph_tot.graph_env import GraphEnvironment, GraphNodeStore, GraphToolInterface
+
+
+class InMemoryStore(GraphNodeStore):
+    def __init__(self):
+        self._nodes = [
+            (
+                "Disease::D001",
+                "Disease",
+                {
+                    "features": {"name": "Diabetes", "mesh_id": "D001"},
+                    "neighbors": {"Compound-treats-Disease": ["Compound::C001"]},
+                },
+            ),
+            (
+                "Compound::C001",
+                "Compound",
+                {
+                    "features": {"name": "Metformin"},
+                    "neighbors": {"Compound-treats-Disease": ["Disease::D001"]},
+                },
+            ),
+        ]
+
+    @property
+    def identity(self) -> str:
+        return "memory://demo-graph-v1"
+
+    def iter_nodes(self):
+        yield from self._nodes
+
+
+class TestGraphBackendProtocol:
+    def test_graph_environment_conforms_to_protocol(self):
+        env = object.__new__(GraphEnvironment)
+        assert isinstance(env, GraphToolInterface)
+
+
+class TestCustomNodeStoreLoading:
+    def test_load_graph_from_custom_store(self):
+        env = object.__new__(GraphEnvironment)
+        env.node_store = InMemoryStore()
+        env.graph = {}
+        env.graph_index = {}
+        env.doc_lookup = []
+        env.doc_type = []
+
+        env._load_graph()
+
+        assert "Disease::D001" in env.graph_index
+        assert env.doc_lookup == ["Disease::D001", "Compound::C001"]
+        assert env.doc_type == ["Disease", "Compound"]


### PR DESCRIPTION
### Motivation
- Provide an extensible graph backend so users can supply domain-specific graphs (Neo4j, RDF/OWL, remote APIs) without changing agent/tool code.
- Preserve existing JSON/pickle workflows while decoupling node loading from the core `GraphEnvironment` logic.

### Description
- Introduce `GraphToolInterface` (protocol) to describe the four-tool contract and `GraphNodeStore` (abstract base) to load nodes from arbitrary sources, plus `JsonPickleGraphStore` as the default loader for current GRBench JSON/pickle files (`src/graph_tot/graph_env.py`).
- Update `GraphEnvironment` to accept an optional `node_store`, load nodes via the store's `iter_nodes()` and use the store `identity` for FAISS cache fingerprinting with a backward-compatible fallback to `graph_path`.
- Export new public API symbols (`GraphToolInterface`, `GraphNodeStore`, `JsonPickleGraphStore`) from the package root (`src/graph_tot/__init__.py`) and document bring-your-own-backend usage in `README.md` including a minimal example.
- Add tests validating protocol conformance and custom store loading via an in-memory store (`tests/test_graph_interface.py`).

### Testing
- Ran `uv run pytest -q tests/test_graph_interface.py tests/test_graph_env_tools.py tests/test_faiss_cache.py tests/test_api_contract.py` which executed the new and existing unit tests.
- Test run result: all tests passed (`64 passed`).
- Existing FAISS cache behavior is preserved and covered by the existing cache tests which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9f859f30832591006ad2a099812a)